### PR TITLE
Feature/missing point on surface methods

### DIFF
--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -1053,6 +1053,21 @@ static VALUE method_geometry_invalid_reason(VALUE self)
   return result;
 }
 
+static VALUE method_geometry_point_on_surface(VALUE self)
+{
+  VALUE result;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+
+  result = Qnil;
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+  if (self_geom) {
+    result = rgeo_wrap_geos_geometry(self_data->factory, GEOSPointOnSurface_r(self_data->geos_context, self_geom), Qnil);
+  }
+  return result;
+}
+
 
 /**** INITIALIZATION FUNCTION ****/
 
@@ -1107,6 +1122,7 @@ void rgeo_init_geos_geometry(RGeo_Globals* globals)
   rb_define_method(geos_geometry_methods, "sym_difference", method_geometry_sym_difference, 1);
   rb_define_method(geos_geometry_methods, "valid?", method_geometry_is_valid, 0);
   rb_define_method(geos_geometry_methods, "invalid_reason", method_geometry_invalid_reason, 0);
+  rb_define_method(geos_geometry_methods, "point_on_surface", method_geometry_point_on_surface, 0);
 }
 
 

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -559,22 +559,6 @@ static VALUE method_multi_polygon_centroid(VALUE self)
 }
 
 
-static VALUE method_multi_polygon_point_on_surface(VALUE self)
-{
-  VALUE result;
-  RGeo_GeometryData* self_data;
-  const GEOSGeometry* self_geom;
-
-  result = Qnil;
-  self_data = RGEO_GEOMETRY_DATA_PTR(self);
-  self_geom = self_data->geom;
-  if (self_geom) {
-    result = rgeo_wrap_geos_geometry(self_data->factory, GEOSPointOnSurface_r(self_data->geos_context, self_geom), Qnil);
-  }
-  return result;
-}
-
-
 static VALUE cmethod_geometry_collection_create(VALUE module, VALUE factory, VALUE array)
 {
   return create_geometry_collection(module, GEOS_GEOMETRYCOLLECTION, factory, array);
@@ -648,7 +632,6 @@ void rgeo_init_geos_geometry_collection(RGeo_Globals* globals)
   rb_define_method(geos_multi_polygon_methods, "geometry_type", method_multi_polygon_geometry_type, 0);
   rb_define_method(geos_multi_polygon_methods, "area", method_multi_polygon_area, 0);
   rb_define_method(geos_multi_polygon_methods, "centroid", method_multi_polygon_centroid, 0);
-  rb_define_method(geos_multi_polygon_methods, "point_on_surface", method_multi_polygon_point_on_surface, 0);
   rb_define_method(geos_multi_polygon_methods, "hash", method_multi_polygon_hash, 0);
   rb_define_method(geos_multi_polygon_methods, "coordinates", method_multi_polygon_coordinates, 0);
 }

--- a/lib/rgeo/geographic/projected_feature_methods.rb
+++ b/lib/rgeo/geographic/projected_feature_methods.rb
@@ -110,6 +110,10 @@ module RGeo
       def sym_difference(rhs)
         factory.unproject(projection.sym_difference(Feature.cast(rhs, factory).projection))
       end
+
+      def point_on_surface
+        factory.unproject(projection.point_on_surface)
+      end
     end
 
     module ProjectedPointMethods # :nodoc:
@@ -169,10 +173,6 @@ module RGeo
 
       def centroid
         factory.unproject(projection.centroid)
-      end
-
-      def point_on_surface
-        factory.unproject(projection.point_on_surface)
       end
     end
 

--- a/lib/rgeo/geos/ffi_feature_methods.rb
+++ b/lib/rgeo/geos/ffi_feature_methods.rb
@@ -266,6 +266,10 @@ module RGeo
         fg
       end
 
+      def point_on_surface
+        @factory.wrap_fg_geom(@fg_geom.point_on_surface, FFIPointImpl)
+      end
+
       private
 
       def request_prepared
@@ -569,10 +573,6 @@ module RGeo
 
       def centroid
         @factory.wrap_fg_geom(@fg_geom.centroid, FFIPointImpl)
-      end
-
-      def point_on_surface
-        @factory.wrap_fg_geom(@fg_geom.point_on_surface, FFIPointImpl)
       end
 
       def coordinates

--- a/test/common/line_string_tests.rb
+++ b/test/common/line_string_tests.rb
@@ -325,11 +325,11 @@ module RGeo
         end
 
         def test_point_on_surface
-          point1 = @factory.point(-7, 6)
-          point2 = @factory.point(-7, 6)
+          point1 = @factory.point(1, 0)
+          point2 = @factory.point(-4, 2)
           point3 = @factory.point(-7, 6)
           line = @factory.line_string([point1, point2, point3])
-          assert_equal(line.point_on_surface, @factory.point(-7, 6))
+          assert_equal(line.point_on_surface, point2)
         end
       end
     end

--- a/test/common/line_string_tests.rb
+++ b/test/common/line_string_tests.rb
@@ -323,6 +323,14 @@ module RGeo
           line2 = Psych.load(data)
           assert_equal(line1, line2)
         end
+
+        def test_point_on_surface
+          point1 = @factory.point(-7, 6)
+          point2 = @factory.point(-7, 6)
+          point3 = @factory.point(-7, 6)
+          line = @factory.line_string([point1, point2, point3])
+          assert_equal(line.point_on_surface, @factory.point(-7, 6))
+        end
       end
     end
   end

--- a/test/common/multi_line_string_tests.rb
+++ b/test/common/multi_line_string_tests.rb
@@ -173,6 +173,11 @@ module RGeo
           ml = @factory.multi_line_string([@linestring1, @linestring2])
           assert_equal(ml.coordinates, [@linestring1, @linestring2].map(&:coordinates))
         end
+
+        def test_point_on_surface
+          ml = @factory.multi_line_string([@linestring1, @linestring2])
+          assert_equal(ml.point_on_surface, @factory.point(-7, 6))
+        end
       end
     end
   end

--- a/test/common/multi_point_tests.rb
+++ b/test/common/multi_point_tests.rb
@@ -193,6 +193,11 @@ module RGeo
           mp = @factory.multi_point(points)
           assert_equal(mp.coordinates, points.map(&:coordinates))
         end
+
+        def test_point_on_surface
+          geom = @factory.multi_point([@point1, @point2, @point3])
+          assert_equal(geom.point_on_surface, @point1)
+        end
       end
     end
   end

--- a/test/common/multi_polygon_tests.rb
+++ b/test/common/multi_polygon_tests.rb
@@ -186,6 +186,10 @@ module RGeo
           multi_polygon = @factory.multi_polygon [poly1, poly2]
           assert_equal(multi_polygon.coordinates, [poly1_coordinates, poly2_coordinates])
         end
+
+        def test_point_on_surface
+          assert_equal(@poly4.point_on_surface, @factory.point(7.5, 5.0))
+        end
       end
     end
   end

--- a/test/common/point_tests.rb
+++ b/test/common/point_tests.rb
@@ -358,6 +358,11 @@ module RGeo
           point2 = Psych.load(data)
           assert_equal(point, point2)
         end
+
+        def test_point_on_surface
+          point = @factory.point(11, 12)
+          assert_equal(point.point_on_surface, point)
+        end
       end
     end
   end

--- a/test/common/polygon_tests.rb
+++ b/test/common/polygon_tests.rb
@@ -252,6 +252,16 @@ module RGeo
           assert(points.first.y == points.last.y)
           assert(points.first.z == points.last.z)
         end
+
+        def test_point_on_surface
+          point1 = @factory.point(0, 0)
+          point2 = @factory.point(0, 10)
+          point3 = @factory.point(10, 10)
+          point4 = @factory.point(10, 0)
+          exterior = @factory.linear_ring([point1, point2, point3, point4, point1])
+          polygon = @factory.polygon(exterior)
+          assert_equal(polygon.point_on_surface, @factory.point(5.0, 5.0))
+        end
       end
     end
   end

--- a/test/simple_cartesian/line_string_test.rb
+++ b/test/simple_cartesian/line_string_test.rb
@@ -21,4 +21,5 @@ class CartesianLineStringTest < Minitest::Test # :nodoc:
   undef_method :test_geometrically_equal_but_different_overlap
   undef_method :test_empty_equal
   undef_method :test_not_equal
+  undef_method :test_point_on_surface
 end

--- a/test/simple_cartesian/multi_line_string_test.rb
+++ b/test/simple_cartesian/multi_line_string_test.rb
@@ -18,4 +18,5 @@ class CartesianMultiLineStringTest < Minitest::Test # :nodoc:
   undef_method :test_fully_equal
   undef_method :test_geometrically_equal
   undef_method :test_not_equal
+  undef_method :test_point_on_surface
 end

--- a/test/simple_cartesian/multi_point_test.rb
+++ b/test/simple_cartesian/multi_point_test.rb
@@ -21,4 +21,5 @@ class CartesianMultiPointTest < Minitest::Test # :nodoc:
   undef_method :test_union
   undef_method :test_difference
   undef_method :test_intersection
+  undef_method :test_point_on_surface
 end

--- a/test/simple_cartesian/multi_polygon_test.rb
+++ b/test/simple_cartesian/multi_polygon_test.rb
@@ -21,4 +21,5 @@ class CartesianMultiPolygonTest < Minitest::Test # :nodoc:
   undef_method :test_creation_connected
   undef_method :test_equal
   undef_method :test_not_equal
+  undef_method :test_point_on_surface
 end

--- a/test/simple_cartesian/point_test.rb
+++ b/test/simple_cartesian/point_test.rb
@@ -52,4 +52,5 @@ class CartesianPointTest < Minitest::Test # :nodoc:
   undef_method :test_union
   undef_method :test_difference
   undef_method :test_sym_difference
+  undef_method :test_point_on_surface
 end

--- a/test/simple_cartesian/polygon_test.rb
+++ b/test/simple_cartesian/polygon_test.rb
@@ -18,4 +18,5 @@ class CartesianPolygonTest < Minitest::Test # :nodoc:
   undef_method :test_fully_equal
   undef_method :test_geometrically_equal_but_ordered_different
   undef_method :test_geometrically_equal_but_different_directions
+  undef_method :test_point_on_surface
 end

--- a/test/simple_mercator/line_string_test.rb
+++ b/test/simple_mercator/line_string_test.rb
@@ -14,4 +14,7 @@ class MercatorLineStringTest < Minitest::Test # :nodoc:
   def setup
     @factory = RGeo::Geographic.simple_mercator_factory
   end
+
+  # These tests suffer from floating point issues
+  undef_method :test_point_on_surface
 end

--- a/test/simple_mercator/multi_line_string_test.rb
+++ b/test/simple_mercator/multi_line_string_test.rb
@@ -16,4 +16,5 @@ class MercatorMultiLineStringTest < Minitest::Test # :nodoc:
   end
 
   undef_method :test_length
+  undef_method :test_point_on_surface
 end

--- a/test/simple_mercator/multi_polygon_test.rb
+++ b/test/simple_mercator/multi_polygon_test.rb
@@ -15,4 +15,7 @@ class MercatorMultiPolygonTest < Minitest::Test # :nodoc:
     @factory = RGeo::Geographic.simple_mercator_factory
     @lenient_factory = RGeo::Geographic.simple_mercator_factory(lenient_multi_polygon_assertions: true)
   end
+
+  # These tests suffer from floating point issues
+  undef_method :test_point_on_surface
 end

--- a/test/simple_mercator/point_test.rb
+++ b/test/simple_mercator/point_test.rb
@@ -41,4 +41,7 @@ class MercatorPointTest < Minitest::Test # :nodoc:
     assert_in_delta(0, point1_.distance(point2_), 0.0001)
     assert_in_delta(222_638, point1_.distance(point3_), 1)
   end
+
+  # These tests suffer from floating point issues
+  undef_method :test_point_on_surface
 end

--- a/test/simple_mercator/polygon_test.rb
+++ b/test/simple_mercator/polygon_test.rb
@@ -14,4 +14,7 @@ class MercatorPolygonTest < Minitest::Test # :nodoc:
   def setup
     @factory = RGeo::Geographic.simple_mercator_factory
   end
+
+  # These tests suffer from floating point issues
+  undef_method :test_point_on_surface
 end

--- a/test/spherical_geographic/line_string_test.rb
+++ b/test/spherical_geographic/line_string_test.rb
@@ -21,4 +21,5 @@ class SphericalLineStringTest < Minitest::Test # :nodoc:
   undef_method :test_geometrically_equal_but_different_overlap
   undef_method :test_empty_equal
   undef_method :test_not_equal
+  undef_method :test_point_on_surface
 end

--- a/test/spherical_geographic/multi_line_string_test.rb
+++ b/test/spherical_geographic/multi_line_string_test.rb
@@ -19,4 +19,5 @@ class SphericalMultiLineStringTest < Minitest::Test # :nodoc:
   undef_method :test_geometrically_equal
   undef_method :test_not_equal
   undef_method :test_length
+  undef_method :test_point_on_surface
 end

--- a/test/spherical_geographic/multi_point_test.rb
+++ b/test/spherical_geographic/multi_point_test.rb
@@ -21,4 +21,5 @@ class SphericalMultiPointTest < Minitest::Test # :nodoc:
   undef_method :test_union
   undef_method :test_difference
   undef_method :test_intersection
+  undef_method :test_point_on_surface
 end

--- a/test/spherical_geographic/multi_polygon_test.rb
+++ b/test/spherical_geographic/multi_polygon_test.rb
@@ -21,4 +21,5 @@ class SphericalMultiPolygonTest < Minitest::Test # :nodoc:
   undef_method :test_creation_connected
   undef_method :test_equal
   undef_method :test_not_equal
+  undef_method :test_point_on_surface
 end

--- a/test/spherical_geographic/point_test.rb
+++ b/test/spherical_geographic/point_test.rb
@@ -68,4 +68,5 @@ class SphericalPointTest < Minitest::Test # :nodoc:
   undef_method :test_union
   undef_method :test_difference
   undef_method :test_sym_difference
+  undef_method :test_point_on_surface
 end

--- a/test/spherical_geographic/polygon_test.rb
+++ b/test/spherical_geographic/polygon_test.rb
@@ -18,4 +18,5 @@ class SphericalPolygonTest < Minitest::Test # :nodoc:
   undef_method :test_fully_equal
   undef_method :test_geometrically_equal_but_ordered_different
   undef_method :test_geometrically_equal_but_different_directions
+  undef_method :test_point_on_surface
 end


### PR DESCRIPTION
### Summary

This PR implements the `Geometry#point_on_surface` method using GEOS CAPI. There is an implementation of `MultiPolygon#point_on_surface` already in the master branch. So, this PR just move existed logic to base feature.

### Other Information

Other features like point and lines, not only polygons should have `point_on_surface` method. It would be more consistent.  In PostGIS [ST_PointOnSurface](https://postgis.net/docs/ST_PointOnSurface.html) works fine with all feature types.